### PR TITLE
Fix: Include organization sponsors

### DIFF
--- a/api/v2/sponsors.go
+++ b/api/v2/sponsors.go
@@ -64,8 +64,14 @@ func getSponsors(username string) string {
 	pastSponsorsContainer := sponsorContainers[1]
 	currentSponsorsContainer := sponsorContainers[0]
 
-	pastSponsors := pastSponsorsContainer.FindAll("a", "data-hovercard-type", "user")
-	currentSponsors := currentSponsorsContainer.FindAll("a", "data-hovercard-type", "user")
+	pastSponsors := append(
+		pastSponsorsContainer.FindAll("a", "data-hovercard-type", "user"),
+		pastSponsorsContainer.FindAll("a", "data-hovercard-type", "organization")...,
+	)
+	currentSponsors := append(
+		currentSponsorsContainer.FindAll("a", "data-hovercard-type", "user"),
+		currentSponsorsContainer.FindAll("a", "data-hovercard-type", "organization")...,
+	)
 
 	if pastSponsorsContainer.Error != nil {
 		return generateErrorResponse("GitHub Sponsors aren't setup with this user. Error: " + pastSponsorsContainer.Error.Error())

--- a/api/v3/sponsors.go
+++ b/api/v3/sponsors.go
@@ -95,7 +95,9 @@ func paginateSponsors(username, filter string) ([]Sponsor, error) {
 
 func parseSponsors(doc soup.Root) []Sponsor {
 	sponsorsList := []Sponsor{}
-	sponsorContainers := doc.FindAll("a", "data-hovercard-type", "user")
+	userSponsors := doc.FindAll("a", "data-hovercard-type", "user")
+	orgSponsors := doc.FindAll("a", "data-hovercard-type", "organization")
+	sponsorContainers := append(userSponsors, orgSponsors...)
 
 	for _, sponsor := range sponsorContainers {
 		img := sponsor.Find("img")


### PR DESCRIPTION
Previously, the tool only extracted sponsors from users and ignored orgs. This PR fixes that by also extracting `data-hovercard-type` = `organization`